### PR TITLE
:sparkles:feat: Simplify dependency injection

### DIFF
--- a/packages/invoc-core/src/InstanceManager.ts
+++ b/packages/invoc-core/src/InstanceManager.ts
@@ -5,9 +5,7 @@ interface IInstanceManager<S = any> {
     args: Array<InjectableDefinition<Class<IInjectable>>>
   ): void;
   unregisterDefinitions(id: Array<string>): void;
-  injectInstance<S extends InstanceType<Class<IInjectable>>>(
-    id: string
-  ): S | null;
+  injectInstance<S extends InstanceType<Class<IInjectable>>>(id: string): S;
   dropInstances(): void;
   listRegisteredIds(): Array<string>;
   serialize(): S;
@@ -131,7 +129,7 @@ class Eager extends InstanceManagementStrategy {
 }
 
 export interface IInjectionMediator {
-  inject(id: string): IInjectable | null;
+  inject(id: string): IInjectable;
 }
 
 class InjectionMediator implements IInjectionMediator {
@@ -140,7 +138,14 @@ class InjectionMediator implements IInjectionMediator {
     this.registry = registry;
   }
   public inject(id: string) {
-    return this.registry.get(id)?.instance ?? null;
+    const res = this.registry.get(id);
+    if (res == null || res.instance == null) {
+      throw new Error(
+        `Could not find instance to inject ${id}, make sure its registered.`
+      );
+    }
+
+    return res.instance;
   }
 }
 
@@ -179,7 +184,11 @@ class InstanceManager<S = any> implements IInstanceManager<S> {
 
   injectInstance<S extends InstanceType<Class<IInjectable>>>(id: string) {
     const res = this.registry.get(id);
-    if (!res || !res.instance) return null;
+    if (res == null || res.instance == null) {
+      throw new Error(
+        `Could not find instance to inject ${id}, make sure its registered.`
+      );
+    }
     return res.instance as S;
   }
 

--- a/packages/invoc-core/src/Service.test.ts
+++ b/packages/invoc-core/src/Service.test.ts
@@ -33,7 +33,7 @@ describe("Service tests", () => {
     });
     class Example extends Service {
       test() {
-        const a = this.inject(ServiceDefinition).instance;
+        const a = this.inject(ServiceDefinition);
         return a;
       }
     }
@@ -48,14 +48,14 @@ describe("Service tests", () => {
     expect(instance?.test()).toBeInstanceOf(TestService);
   });
 
-  it("Should return null if injected service is not registerred", () => {
+  it("Should throw if injected service is not registerred", () => {
     const im = new InstanceManager({
       instantiation: Eager,
       serialization: JSONString,
     });
     class Example extends Service {
       test() {
-        const a = this.inject(ServiceDefinition).instance;
+        const a = this.inject(ServiceDefinition);
         return a;
       }
     }
@@ -65,8 +65,9 @@ describe("Service tests", () => {
     });
 
     im.registerDefinitions([ExampleDef]);
-
-    const instance = im.injectInstance<Example>(ExampleDef.id);
-    expect(instance?.test()).toBeNull();
+    const helper = () => {
+      im.injectInstance<Example>(ExampleDef.id).test();
+    };
+    expect(helper).toThrow(Error);
   });
 });

--- a/packages/invoc-core/src/Service.ts
+++ b/packages/invoc-core/src/Service.ts
@@ -11,17 +11,7 @@ abstract class Service implements IInjectable, IInjector {
     class: T;
     id: string;
   }) => {
-    const im = this.im;
-    return {
-      get instance() {
-        const lookup = im.inject(store.id);
-        if (lookup == null) {
-          return null;
-        }
-
-        return lookup as InstanceType<T>;
-      },
-    };
+    return this.im.inject(store.id) as InstanceType<T>;
   };
 
   readonly serialize?: () => any;

--- a/packages/invoc-core/src/types/index.ts
+++ b/packages/invoc-core/src/types/index.ts
@@ -43,9 +43,10 @@ interface Ilookup<T, V> {
 }
 
 interface IInjector {
-  inject(id: { id: string; class: Class<IInjectable> }): {
-    instance: InstanceType<Class<IInjectable>> | null;
-  };
+  inject(id: {
+    id: string;
+    class: Class<IInjectable>;
+  }): InstanceType<Class<IInjectable>>;
 }
 
 interface IInjectable {


### PR DESCRIPTION
* Make injection optimistic for the case where the dependency was not found.
* Throw error instead of returning null to reduce number of nullchecks

This closes #12